### PR TITLE
fix: fixes performance updates and removes animation for progressbars

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -12,6 +12,7 @@ import (
 	"github.com/amir20/dtop/internal/ui/components/table"
 
 	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/progress"
 	"github.com/charmbracelet/bubbles/spinner"
 	teaTable "github.com/charmbracelet/bubbles/table"
 	"github.com/charmbracelet/lipgloss"
@@ -33,6 +34,9 @@ func NewModel(ctx context.Context, client *docker.Client, defaultSort config.Sor
 		fmt.Println("Error:", err)
 		os.Exit(1)
 	}
+
+	// Create a static progress bar for rendering with ViewAs()
+	progressBar := progress.New(progress.WithDefaultGradient())
 
 	tbl := table.New(
 		table.WithColumns([]table.Column[row]{
@@ -74,12 +78,12 @@ func NewModel(ctx context.Context, client *docker.Client, defaultSort config.Sor
 			{
 				Title: "CPU", Width: 10, Renderer: func(col table.Column[row], r row, selected bool) string {
 					if r.container.State == "running" {
-						bar := r.cpu
+						bar := progressBar
 						bar.Width = col.Width
 						if selected {
 							bar.PercentageStyle = selectedStyle
 						}
-						return bar.View()
+						return bar.ViewAs(r.cpuPercent)
 					}
 					return lipgloss.NewStyle().Width(col.Width).Inline(true).Render("")
 				},
@@ -87,12 +91,12 @@ func NewModel(ctx context.Context, client *docker.Client, defaultSort config.Sor
 			{
 				Title: "MEMORY", Width: 10, Renderer: func(col table.Column[row], r row, selected bool) string {
 					if r.container.State == "running" {
-						bar := r.mem
+						bar := progressBar
 						bar.Width = col.Width
 						if selected {
 							bar.PercentageStyle = selectedStyle
 						}
-						return bar.View()
+						return bar.ViewAs(r.memPercent)
 					}
 					return lipgloss.NewStyle().Width(col.Width).Inline(true).Render("")
 				},

--- a/internal/ui/types.go
+++ b/internal/ui/types.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
-	"github.com/charmbracelet/bubbles/progress"
 	"github.com/charmbracelet/bubbles/spinner"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -18,8 +17,8 @@ import (
 
 type row struct {
 	container              *docker.Container
-	cpu                    progress.Model
-	mem                    progress.Model
+	cpuPercent             float64
+	memPercent             float64
 	lastUpdate             time.Time
 	totalBytesReceived     uint64
 	totalBytesSent         uint64
@@ -30,8 +29,6 @@ type row struct {
 func newRow(container *docker.Container) row {
 	return row{
 		container: container,
-		cpu:       progress.New(progress.WithDefaultGradient()),
-		mem:       progress.New(progress.WithDefaultGradient()),
 	}
 }
 
@@ -54,7 +51,7 @@ type model struct {
 type tickMsg time.Time
 
 func tick() tea.Cmd {
-	return tea.Tick(time.Millisecond*100, func(t time.Time) tea.Msg {
+	return tea.Tick(time.Millisecond*200, func(t time.Time) tea.Msg {
 		return tickMsg(t)
 	})
 }


### PR DESCRIPTION
## Problem  
I've noticed that high CPU usage (~24%) is happening because `View()` is being called around 52 times every second. This is mainly due to progress bar animations that continuously send `progress.FrameMsg` updates.

### Solution  
-    **Tick-based rendering**: I’ve shifted UI updates to occur every 200ms (~5 FPS) instead of with every stat update.  
-    **Static progress bars**: I replaced the animated `progress.Model` instances with `float64` percentages, using `ViewAs()` for a more straightforward rendering.  
-    **Removed animation loop**: I’ve eliminated the progress bar `.Update()` calls that were causing cascading re-renders.  

### Impact  
-    I’ve reduced `View()` calls from about 52 per second to just 5 per second.  
-    There are now zero `progress.FrameMsg` animation messages.  
-    I expect a CPU reduction of 40-60%.  

See https://github.com/amir20/dtop/issues/44