### PR TITLE
feat: add vim-style j/k navigation support

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -23,12 +23,12 @@ pub fn keyboard_worker(tx: EventSender) {
                         let _ = tx.blocking_send(AppEvent::Quit);
                         break;
                     }
-                    KeyCode::Up => {
+                    KeyCode::Up | KeyCode::Char('k') => {
                         // Send both events - handler will decide based on view state
                         let _ = tx.blocking_send(AppEvent::SelectPrevious);
                         let _ = tx.blocking_send(AppEvent::ScrollUp);
                     }
-                    KeyCode::Down => {
+                    KeyCode::Down | KeyCode::Char('j') => {
                         // Send both events - handler will decide based on view state
                         let _ = tx.blocking_send(AppEvent::SelectNext);
                         let _ = tx.blocking_send(AppEvent::ScrollDown);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -451,7 +451,7 @@ fn render_help_popup(f: &mut Frame, styles: &UiStyles) {
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
         )]),
-        Line::from("  ↑/↓         Navigate containers or scroll logs"),
+        Line::from("  ↑/↓ or j/k  Navigate containers or scroll logs"),
         Line::from("  Enter       View logs for selected container"),
         Line::from("  Esc         Exit log view or close help"),
         Line::from("  o           Open container in Dozzle (if configured)"),


### PR DESCRIPTION
Add support for j/k keys for navigation in both container list view and log view. This provides a familiar vim-style navigation experience alongside the existing arrow key navigation.

- j key now works like Down arrow (move down/scroll down)
- k key now works like Up arrow (move up/scroll up)
- Updated help popup to document the new keybindings