### PR TITLE
Add `./.dtop.y(a)ml` configuration file locations in comments

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,7 +1,7 @@
 # Docker Monitor Configuration
 #
 # This file can be placed in one of the following locations (in priority order):
-# 1. ./config.yaml or ./config.yml (relative to current directory)
+# 1. ./config.yaml, ./config.yml, ./.dtop.yaml, or ./.dtop.yml (relative to current directory)
 # 2. ~/.config/dtop/config.yaml or ~/.config/dtop/config.yml
 # 3. ~/.dtop.yaml or ~/.dtop.yml
 #


### PR DESCRIPTION
Ref 6be1e68809cbc84d62787d421e7f781d612decd6

Little update to the inline documentation in the example file for completeness sake.