### PR TITLE
fixi: fixes UI render issue for white theme users

### DIFF
--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -36,7 +36,7 @@ impl Default for UiStyles {
             header: Style::default()
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
-            border: Style::default().fg(Color::White),
+            border: Style::default(),
             selected: Style::default()
                 .bg(Color::DarkGray)
                 .add_modifier(Modifier::BOLD),


### PR DESCRIPTION
- UI was showing blank text for white theme users
- Please take a look at fixed UI for white theme in attached image

<img width="1820" height="258" alt="Screenshot From 2025-12-02 12-48-59" src="https://github.com/user-attachments/assets/490d4d5e-ec1c-42ab-ab23-9aa70f299ea5" />

- For black theme

<img width="1820" height="258" alt="Screenshot From 2025-12-02 12-56-52" src="https://github.com/user-attachments/assets/172e3432-1dd6-4feb-977d-aa58cce6126e" />

