### PR TITLE
fix: prevent panics and improve keyboard handling in search mode

### DIFF
--- a/.claude/agent-memory/rust-optimizer/MEMORY.md
+++ b/.claude/agent-memory/rust-optimizer/MEMORY.md
@@ -1,0 +1,37 @@
+# dtop Codebase Knowledge
+
+## Architecture
+- Event-driven TUI: Tokio runtime, mpsc channels, Ratatui rendering at 500ms
+- Multi-host Docker monitoring via Bollard (SSH, TCP, TLS, local)
+- One `container_manager` async task per host, one stats stream per container
+- Keyboard input runs on a blocking OS thread (crossterm polling at 200ms)
+- AppState is modular: actions, container_events, integrations, log_view, navigation, search, sorting
+
+## Key Performance Patterns
+- Styles pre-allocated in `UiStyles` (not per-frame)
+- Sort throttled to every 3s (`SORT_THROTTLE_DURATION`), force_sort bypasses
+- Log text parsed at arrival (ANSI, JSON), cached as `Text<'static>` in `LogEntry`
+- Log view only formats visible lines (window slicing in `render_log_view`)
+- Stats smoothed with EMA (alpha=0.3)
+
+## Known Issues Identified (2026-02-15 full review)
+1. **Keyboard worker sends duplicate events**: Every key sends SearchKeyEvent AND the specific event. In SearchMode, both get processed. The sort/navigation handlers guard with `view_state != ContainerList`, but keys like 'q' send Quit unconditionally -- typing 'q' in search exits the app.
+2. **Sorting does double HashMap lookups**: `sort_containers_internal` iterates keys, calls `self.containers.get(key)` in filter, then clones keys, then looks up again in sort comparators -- each comparator does `self.containers.get().unwrap()`.
+3. **Per-frame allocations in render**: `format!()` for progress bars, `String::new()` for empty fields, `Vec<Row>` collected per render. Header row creates `String` per column.
+4. **`unwrap()` in sort comparators**: `self.containers.get(a).unwrap()` can panic if container removed between filter and sort (race with event processing).
+5. **`LogEntry::clone()` on every log line**: `handle_log_line` clones the LogEntry (which contains `Text<'static>` with heap-allocated spans).
+6. **`Formatter::new()` created per container per render**: `format_time_elapsed` creates a new `timeago::Formatter` on every call.
+7. **`truncate_string` doesn't handle multi-byte chars**: byte slicing `&s[..max_len-1]` can panic on multi-byte UTF-8.
+
+## File Layout
+- `src/main.rs` - Entry, event loop, terminal setup
+- `src/core/types.rs` - AppEvent, Container, ContainerKey, ViewState, SortField
+- `src/core/app_state/mod.rs` - Central state, handle_event dispatch
+- `src/core/app_state/sorting.rs` - sort_containers_internal with throttling
+- `src/docker/connection.rs` - DockerHost, container_manager, connect_docker
+- `src/docker/stats.rs` - stream_container_stats with EMA smoothing
+- `src/docker/logs.rs` - LogEntry::parse, stream/fetch_older_logs
+- `src/ui/render.rs` - render_ui, UiStyles, search/error overlays
+- `src/ui/container_list.rs` - Table rendering with progress bars
+- `src/ui/log_view.rs` - Log viewer with scrollbar + pagination
+- `src/ui/input.rs` - keyboard_worker (blocking thread)

--- a/src/core/app_state/log_view.rs
+++ b/src/core/app_state/log_view.rs
@@ -225,11 +225,14 @@ impl AppState {
             return RenderAction::None;
         }
 
-        // Store the raw log entry
-        state.log_entries.push(log_entry.clone());
+        // Extract timestamp before moving log_entry
+        let timestamp = log_entry.timestamp;
+
+        // Store the raw log entry (already owned, no clone needed)
+        state.log_entries.push(log_entry);
 
         // Update newest timestamp for progress calculation
-        state.newest_timestamp = Some(log_entry.timestamp);
+        state.newest_timestamp = Some(timestamp);
 
         RenderAction::Render
     }

--- a/src/core/app_state/mod.rs
+++ b/src/core/app_state/mod.rs
@@ -119,6 +119,11 @@ impl AppState {
             }
             AppEvent::Resize => RenderAction::Render, // Always redraw on resize
             AppEvent::Quit => {
+                // Don't quit if in search mode - 'q' was meant as search input
+                // (Ctrl+C bypasses this by sending Quit before SearchKeyEvent)
+                if self.view_state == ViewState::SearchMode {
+                    return RenderAction::None;
+                }
                 self.should_quit = true;
                 RenderAction::None
             }

--- a/src/core/app_state/navigation.rs
+++ b/src/core/app_state/navigation.rs
@@ -8,7 +8,7 @@ impl AppState {
             return RenderAction::None;
         }
 
-        let container_count = self.containers.len();
+        let container_count = self.sorted_container_keys.len();
         if container_count > 0 {
             let selected = self.table_state.selected().unwrap_or(0);
             if selected > 0 {
@@ -24,7 +24,7 @@ impl AppState {
             return RenderAction::None;
         }
 
-        let container_count = self.containers.len();
+        let container_count = self.sorted_container_keys.len();
         if container_count > 0 {
             let selected = self.table_state.selected().unwrap_or(0);
             if selected < container_count - 1 {
@@ -35,6 +35,10 @@ impl AppState {
     }
 
     pub(super) fn handle_toggle_help(&mut self) -> RenderAction {
+        // Don't toggle help in search mode - '?' was meant as search input
+        if self.view_state == ViewState::SearchMode {
+            return RenderAction::None;
+        }
         self.show_help = !self.show_help;
         RenderAction::Render // Force redraw to show/hide popup
     }

--- a/src/core/app_state/sorting.rs
+++ b/src/core/app_state/sorting.rs
@@ -134,8 +134,11 @@ impl AppState {
         match self.sort_state.field {
             SortField::Uptime => {
                 self.sorted_container_keys.sort_by(|a, b| {
-                    let container_a = self.containers.get(a).unwrap();
-                    let container_b = self.containers.get(b).unwrap();
+                    let (Some(container_a), Some(container_b)) =
+                        (self.containers.get(a), self.containers.get(b))
+                    else {
+                        return std::cmp::Ordering::Equal;
+                    };
 
                     // First by host_id
                     match container_a.host_id.cmp(&container_b.host_id) {
@@ -160,8 +163,11 @@ impl AppState {
             }
             SortField::Name => {
                 self.sorted_container_keys.sort_by(|a, b| {
-                    let container_a = self.containers.get(a).unwrap();
-                    let container_b = self.containers.get(b).unwrap();
+                    let (Some(container_a), Some(container_b)) =
+                        (self.containers.get(a), self.containers.get(b))
+                    else {
+                        return std::cmp::Ordering::Equal;
+                    };
 
                     // First by host_id
                     match container_a.host_id.cmp(&container_b.host_id) {
@@ -180,8 +186,11 @@ impl AppState {
             }
             SortField::Cpu => {
                 self.sorted_container_keys.sort_by(|a, b| {
-                    let container_a = self.containers.get(a).unwrap();
-                    let container_b = self.containers.get(b).unwrap();
+                    let (Some(container_a), Some(container_b)) =
+                        (self.containers.get(a), self.containers.get(b))
+                    else {
+                        return std::cmp::Ordering::Equal;
+                    };
 
                     // First by host_id
                     match container_a.host_id.cmp(&container_b.host_id) {
@@ -204,8 +213,11 @@ impl AppState {
             }
             SortField::Memory => {
                 self.sorted_container_keys.sort_by(|a, b| {
-                    let container_a = self.containers.get(a).unwrap();
-                    let container_b = self.containers.get(b).unwrap();
+                    let (Some(container_a), Some(container_b)) =
+                        (self.containers.get(a), self.containers.get(b))
+                    else {
+                        return std::cmp::Ordering::Equal;
+                    };
 
                     // First by host_id
                     match container_a.host_id.cmp(&container_b.host_id) {

--- a/src/ui/action_menu.rs
+++ b/src/ui/action_menu.rs
@@ -109,11 +109,12 @@ pub fn render_action_menu(f: &mut Frame, state: &mut AppState, styles: &UiStyles
     f.render_widget(footer, footer_area);
 }
 
-/// Truncates a string to the specified length, adding ellipsis if needed
+/// Truncates a string to the specified character length, adding ellipsis if needed
 fn truncate_string(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
+    if s.chars().count() <= max_len {
         s.to_string()
     } else {
-        format!("{}…", &s[..max_len.saturating_sub(1)])
+        let truncated: String = s.chars().take(max_len.saturating_sub(1)).collect();
+        format!("{}…", truncated)
     }
 }

--- a/src/ui/formatters.rs
+++ b/src/ui/formatters.rs
@@ -1,7 +1,10 @@
 //! Formatting utilities for displaying values in the UI
 
 use chrono::Utc;
+use std::sync::LazyLock;
 use timeago::Formatter;
+
+static TIMEAGO_FORMATTER: LazyLock<Formatter> = LazyLock::new(Formatter::new);
 
 const KB: f64 = 1024.0;
 const MB: f64 = KB * 1024.0;
@@ -42,9 +45,8 @@ pub fn format_bytes_per_sec(bytes_per_sec: f64) -> String {
 pub fn format_time_elapsed(created: Option<&chrono::DateTime<Utc>>) -> String {
     match created {
         Some(created_time) => {
-            let formatter = Formatter::new();
             let now = Utc::now();
-            formatter.convert_chrono(*created_time, now)
+            TIMEAGO_FORMATTER.convert_chrono(*created_time, now)
         }
         None => "Unknown".to_string(),
     }


### PR DESCRIPTION
- Fix keyboard shortcuts (q, ?) firing during search mode input
- Ctrl+C still quits immediately from any view state
- Replace unwrap() in sort comparators with safe fallback
- Fix UTF-8 panic in truncate_string for multi-byte container names
- Remove unnecessary LogEntry clone on hot path
- Use static LazyLock for timeago::Formatter instead of per-frame allocation
- Use sorted_container_keys.len() for navigation bounds

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
