### PR TITLE
fix: container state icon stuck in restarting after restart

### DIFF
--- a/src/core/app_state/container_events.rs
+++ b/src/core/app_state/container_events.rs
@@ -28,8 +28,14 @@ impl AppState {
 
     pub(super) fn handle_container_created(&mut self, container: Container) -> RenderAction {
         let key = ContainerKey::new(container.host_id.clone(), container.id.clone());
+        let is_new = !self.containers.contains_key(&key);
         self.containers.insert(key.clone(), container);
-        self.sorted_container_keys.push(key);
+
+        // Only add to sorted keys if this is a genuinely new container
+        // (avoid duplicates during restarts where container already exists)
+        if is_new {
+            self.sorted_container_keys.push(key);
+        }
 
         // Force immediate sort when new container is added
         self.force_sort_containers();

--- a/src/docker/connection.rs
+++ b/src/docker/connection.rs
@@ -317,9 +317,7 @@ impl DockerHost {
             } else {
                 // Container already monitored (e.g., "start" event without preceding "die")
                 // — just update the state to Running
-                let _ = tx
-                    .send(AppEvent::ContainerStateChanged(key, state))
-                    .await;
+                let _ = tx.send(AppEvent::ContainerStateChanged(key, state)).await;
             }
         }
     }

--- a/src/docker/connection.rs
+++ b/src/docker/connection.rs
@@ -254,6 +254,7 @@ impl DockerHost {
         active_containers: &mut HashMap<String, tokio::task::JoinHandle<()>>,
     ) {
         let truncated_id = container_id[..12.min(container_id.len())].to_string();
+        let key = ContainerKey::new(self.host_id.clone(), truncated_id.clone());
 
         // Get container details
         if let Ok(inspect) = self
@@ -267,12 +268,10 @@ impl DockerHost {
                 .map(|n| n.trim_start_matches('/').to_string())
                 .unwrap_or_default();
 
-            let state = inspect
-                .state
-                .as_ref()
-                .and_then(|s| s.status.as_ref())
-                .and_then(|s| format!("{:?}", s).parse().ok())
-                .unwrap_or(ContainerState::Unknown);
+            // We received a "start" event, so the container is running.
+            // Don't trust inspect state here — there's a race where inspect
+            // can still report "restarting" right after the start event fires.
+            let state = ContainerState::Running;
 
             // Parse health status from state (None if no health check configured)
             let health = inspect
@@ -297,8 +296,8 @@ impl DockerHost {
                 .and_then(|config| config.labels.as_ref())
                 .and_then(|labels| labels.get("com.docker.compose.project").cloned());
 
-            // Start monitoring the new container
             if !active_containers.contains_key(&truncated_id) {
+                // New container or restarted container — create/update and start monitoring
                 let container = Container {
                     id: truncated_id.clone(),
                     name: name.clone(),
@@ -315,6 +314,12 @@ impl DockerHost {
                 let _ = tx.send(AppEvent::ContainerCreated(container)).await;
 
                 self.start_container_monitoring(&truncated_id, tx, active_containers);
+            } else {
+                // Container already monitored (e.g., "start" event without preceding "die")
+                // — just update the state to Running
+                let _ = tx
+                    .send(AppEvent::ContainerStateChanged(key, state))
+                    .await;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fix container state icon getting stuck in "restarting" after a restart completes (#276)
- When handling a Docker "start" event, use `ContainerState::Running` directly instead of trusting the inspect API result, which can race and still report "restarting"
- Also send a state update when a "start" event arrives for an already-monitored container (e.g., restart without preceding "die" event)
- Prevent duplicate entries in `sorted_container_keys` when `ContainerCreated` fires for an existing container during restart

## Test plan
- [x] `cargo clippy` passes
- [x] `cargo test` — all 196 tests pass
- [ ] Manual: restart a container via dtop over SSH — state icon should return to running
- [ ] Manual: restart a container via dtop locally — verify same behavior

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)