### PR TITLE
fix(sort): sort containers globally across all hosts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -545,7 +545,7 @@ The UI (`ui/render.rs`) uses pre-allocated styles to avoid per-frame allocations
 **Sorting:** Containers can be sorted by multiple fields:
 - Default sort: Uptime (newest first, descending)
 - Sort fields: Uptime, Name, CPU, Memory
-- Containers are always sorted by `host_id` first, then by the selected field within each host
+- Containers are sorted globally across all hosts by the selected field, with `host_id` as tiebreaker
 - Press 's' to open sort selector popup
 - In the sort popup, select a field to sort by; selecting the active field toggles direction
 - Each field has a default direction: Name (ascending), Uptime/CPU/Memory (descending)
@@ -775,9 +775,11 @@ Run tests with `cargo test` or `cargo insta test` for snapshot tests.
 
 ## Pre-Commit Checklist
 
+**IMPORTANT: These checks MUST pass before creating any PR or commit.**
+
 Before committing or submitting a pull request, always run:
-1. `cargo fmt` - Fix formatting
-2. `cargo clippy` - Fix all warnings
+1. `cargo fmt --check` - Verify formatting (run `cargo fmt` to fix)
+2. `cargo clippy` - Ensure no warnings
 3. `cargo test` - Ensure all tests pass
 4. `cargo insta accept` - Accept any updated snapshots (if applicable)
 

--- a/src/core/app_state/sorting.rs
+++ b/src/core/app_state/sorting.rs
@@ -145,53 +145,52 @@ impl AppState {
         let direction = self.sort_state.direction;
         let sort_field = self.sort_state.field;
 
-        key_container_pairs.sort_by(|(_, a), (_, b)| match a.host_id.cmp(&b.host_id) {
-            std::cmp::Ordering::Equal => {
-                let ord = match sort_field {
-                    Column::Uptime => match (&a.created, &b.created) {
-                        (Some(a_time), Some(b_time)) => a_time.cmp(b_time),
-                        (Some(_), None) => std::cmp::Ordering::Greater,
-                        (None, Some(_)) => std::cmp::Ordering::Less,
-                        (None, None) => std::cmp::Ordering::Equal,
-                    },
-                    Column::Name => a.name.cmp(&b.name),
-                    Column::Id => a.id.cmp(&b.id),
-                    Column::Host => a.host_id.cmp(&b.host_id),
-                    Column::Compose => a.compose_project.cmp(&b.compose_project),
-                    Column::Cpu => a
-                        .stats
-                        .cpu
-                        .partial_cmp(&b.stats.cpu)
-                        .unwrap_or(std::cmp::Ordering::Equal),
-                    Column::Memory => a
-                        .stats
-                        .memory
-                        .partial_cmp(&b.stats.memory)
-                        .unwrap_or(std::cmp::Ordering::Equal),
-                    Column::NetTx => a
-                        .stats
-                        .network_tx_bytes_per_sec
-                        .partial_cmp(&b.stats.network_tx_bytes_per_sec)
-                        .unwrap_or(std::cmp::Ordering::Equal),
-                    Column::NetRx => a
-                        .stats
-                        .network_rx_bytes_per_sec
-                        .partial_cmp(&b.stats.network_rx_bytes_per_sec)
-                        .unwrap_or(std::cmp::Ordering::Equal),
-                    Column::Status => {
-                        let a_state = format!("{:?}", a.state);
-                        let b_state = format!("{:?}", b.state);
-                        a_state.cmp(&b_state)
-                    }
-                    Column::Restarts => a.restart_count.cmp(&b.restart_count),
-                };
-                if direction == SortDirection::Descending {
-                    ord.reverse()
-                } else {
-                    ord
+        key_container_pairs.sort_by(|(_, a), (_, b)| {
+            let ord = match sort_field {
+                Column::Uptime => match (&a.created, &b.created) {
+                    (Some(a_time), Some(b_time)) => a_time.cmp(b_time),
+                    (Some(_), None) => std::cmp::Ordering::Greater,
+                    (None, Some(_)) => std::cmp::Ordering::Less,
+                    (None, None) => std::cmp::Ordering::Equal,
+                },
+                Column::Name => a.name.cmp(&b.name),
+                Column::Id => a.id.cmp(&b.id),
+                Column::Host => a.host_id.cmp(&b.host_id),
+                Column::Compose => a.compose_project.cmp(&b.compose_project),
+                Column::Cpu => a
+                    .stats
+                    .cpu
+                    .partial_cmp(&b.stats.cpu)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+                Column::Memory => a
+                    .stats
+                    .memory
+                    .partial_cmp(&b.stats.memory)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+                Column::NetTx => a
+                    .stats
+                    .network_tx_bytes_per_sec
+                    .partial_cmp(&b.stats.network_tx_bytes_per_sec)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+                Column::NetRx => a
+                    .stats
+                    .network_rx_bytes_per_sec
+                    .partial_cmp(&b.stats.network_rx_bytes_per_sec)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+                Column::Status => {
+                    let a_state = format!("{:?}", a.state);
+                    let b_state = format!("{:?}", b.state);
+                    a_state.cmp(&b_state)
                 }
-            }
-            other => other,
+                Column::Restarts => a.restart_count.cmp(&b.restart_count),
+            };
+            let ord = if direction == SortDirection::Descending {
+                ord.reverse()
+            } else {
+                ord
+            };
+            // Use host_id as tiebreaker for stable ordering
+            ord.then_with(|| a.host_id.cmp(&b.host_id))
         });
 
         // Extract sorted keys


### PR DESCRIPTION
## Summary
- Containers are now sorted globally across all hosts instead of being grouped by host first
- `host_id` is used only as a tiebreaker when sort values are equal
- This fixes misleading sort order in multi-host setups where high-usage containers on one host ranked below low-usage containers on another

Closes #277

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes  
- [x] All 103 tests pass
- [ ] Manual test with multi-host setup: verify sorting by CPU/Memory ranks containers globally

🤖 Generated with [Claude Code](https://claude.com/claude-code)