### PR TITLE
Add allocation-regression tests and optimize hot-path rendering

### DIFF
--- a/src/alloc_counter.rs
+++ b/src/alloc_counter.rs
@@ -62,9 +62,20 @@ unsafe impl GlobalAlloc for CountingAllocator {
 /// Nested/parallel measurements on the same thread are not supported; this is
 /// intended to wrap a single hot-path call in a test.
 pub fn count_allocations<F: FnOnce()>(f: F) -> u64 {
+    // Disable counting on drop so a panic inside `f` cannot leave `ENABLED`
+    // stuck at `true`. The test harness reuses worker threads, so a leaked
+    // flag would silently pollute later measurements on the same thread (and
+    // count allocations performed during unwinding).
+    struct DisableOnDrop;
+    impl Drop for DisableOnDrop {
+        fn drop(&mut self) {
+            ENABLED.with(|e| e.set(false));
+        }
+    }
+
     COUNT.with(|c| c.set(0));
+    let _guard = DisableOnDrop;
     ENABLED.with(|e| e.set(true));
     f();
-    ENABLED.with(|e| e.set(false));
     COUNT.with(|c| c.get())
 }

--- a/src/alloc_counter.rs
+++ b/src/alloc_counter.rs
@@ -1,0 +1,70 @@
+//! A test-only allocation-counting global allocator.
+//!
+//! This wraps the system allocator and, while enabled on the current thread,
+//! counts every `alloc`/`realloc` call. It is used by allocation-regression
+//! tests to measure how many heap allocations a hot path performs so we can
+//! drive that number as close to zero as possible and prevent regressions.
+//!
+//! Counting is thread-local so that tests running in parallel (the default for
+//! `cargo test`) do not pollute each other's measurements.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+
+thread_local! {
+    static ENABLED: Cell<bool> = const { Cell::new(false) };
+    static COUNT: Cell<u64> = const { Cell::new(0) };
+}
+
+/// Global allocator that counts allocations on the current thread when enabled.
+pub struct CountingAllocator;
+
+#[inline]
+fn record_alloc() {
+    // `try_with` avoids panicking if accessed during thread-local teardown.
+    let _ = ENABLED.try_with(|enabled| {
+        if enabled.get() {
+            let _ = COUNT.try_with(|count| count.set(count.get() + 1));
+        }
+    });
+}
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        record_alloc();
+        // SAFETY: forwarding to the system allocator with the same layout.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: forwarding to the system allocator with the original ptr/layout.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        record_alloc();
+        // SAFETY: forwarding to the system allocator with the same layout.
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // A realloc that grows a buffer is itself an allocation event we care
+        // about (e.g. a `Vec` outgrowing its capacity mid-render).
+        record_alloc();
+        // SAFETY: forwarding to the system allocator with the original ptr/layout.
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+/// Runs `f`, returning the number of allocations performed on the current
+/// thread during its execution.
+///
+/// Nested/parallel measurements on the same thread are not supported; this is
+/// intended to wrap a single hot-path call in a test.
+pub fn count_allocations<F: FnOnce()>(f: F) -> u64 {
+    COUNT.with(|c| c.set(0));
+    ENABLED.with(|e| e.set(true));
+    f();
+    ENABLED.with(|e| e.set(false));
+    COUNT.with(|c| c.get())
+}

--- a/src/core/app_state/mod.rs
+++ b/src/core/app_state/mod.rs
@@ -28,8 +28,9 @@ pub struct AppState {
     pub sorted_container_keys: Vec<ContainerKey>,
     /// Reusable buffer of currently visible columns, refreshed each frame in
     /// place (clear + extend) so rendering does not allocate a new `Vec` per
-    /// frame. See `refresh_visible_columns`.
-    pub visible_columns_cache: Vec<Column>,
+    /// frame. Internal render scratch space — read only after calling
+    /// [`AppState::refresh_visible_columns`], hence `pub(crate)`.
+    pub(crate) visible_columns_cache: Vec<Column>,
     /// Whether the application should quit
     pub should_quit: bool,
     /// Table selection state
@@ -139,7 +140,7 @@ impl AppState {
     ///
     /// Reuses the existing `Vec`'s capacity (`clear` + `extend`), so after the
     /// first frame this does not allocate even though it runs every frame.
-    pub fn refresh_visible_columns(&mut self) {
+    pub(crate) fn refresh_visible_columns(&mut self) {
         self.visible_columns_cache.clear();
         self.visible_columns_cache.extend(
             self.column_config

--- a/src/core/app_state/mod.rs
+++ b/src/core/app_state/mod.rs
@@ -26,6 +26,10 @@ pub struct AppState {
     pub containers: HashMap<ContainerKey, Container>,
     /// Pre-sorted list of container keys for efficient rendering
     pub sorted_container_keys: Vec<ContainerKey>,
+    /// Reusable buffer of currently visible columns, refreshed each frame in
+    /// place (clear + extend) so rendering does not allocate a new `Vec` per
+    /// frame. See `refresh_visible_columns`.
+    pub visible_columns_cache: Vec<Column>,
     /// Whether the application should quit
     pub should_quit: bool,
     /// Table selection state
@@ -87,6 +91,7 @@ impl AppState {
         Self {
             containers: HashMap::new(),
             sorted_container_keys: Vec::new(),
+            visible_columns_cache: Vec::new(),
             should_quit: false,
             table_state: TableState::default(),
             view_state: ViewState::ContainerList,
@@ -111,6 +116,38 @@ impl AppState {
             connection_errors: HashMap::new(),
             last_sort_time: Instant::now(),
         }
+    }
+
+    /// Returns true if containers span more than one Docker host.
+    ///
+    /// This is used every frame to decide whether to show the "Host" column.
+    /// It iterates keys with an early return instead of collecting into a
+    /// `HashSet`, so it performs no heap allocation.
+    pub fn has_multiple_hosts(&self) -> bool {
+        let mut first: Option<&str> = None;
+        for key in self.containers.keys() {
+            match first {
+                None => first = Some(key.host_id.as_str()),
+                Some(h) if h != key.host_id.as_str() => return true,
+                _ => {}
+            }
+        }
+        false
+    }
+
+    /// Rebuilds the cached list of visible columns in place.
+    ///
+    /// Reuses the existing `Vec`'s capacity (`clear` + `extend`), so after the
+    /// first frame this does not allocate even though it runs every frame.
+    pub fn refresh_visible_columns(&mut self) {
+        self.visible_columns_cache.clear();
+        self.visible_columns_cache.extend(
+            self.column_config
+                .columns
+                .iter()
+                .filter(|(_, visible)| *visible)
+                .map(|(col, _)| *col),
+        );
     }
 
     /// Processes a single event and returns what action to take

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,11 @@
+// Test-only allocation counting allocator, used by allocation-regression tests.
+#[cfg(test)]
+mod alloc_counter;
+
+#[cfg(test)]
+#[global_allocator]
+static GLOBAL_ALLOC: alloc_counter::CountingAllocator = alloc_counter::CountingAllocator;
+
 // Core modules
 pub mod core {
     pub mod app_state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,17 @@ mod core;
 mod docker;
 mod ui;
 
+// Test-only allocation counting allocator. `main.rs` is a separate crate root
+// that recompiles the module tree (including the allocation-regression tests),
+// so it needs its own copy of the allocator and global registration.
+#[cfg(test)]
+#[path = "alloc_counter.rs"]
+mod alloc_counter;
+
+#[cfg(test)]
+#[global_allocator]
+static GLOBAL_ALLOC: alloc_counter::CountingAllocator = alloc_counter::CountingAllocator;
+
 use clap::Parser;
 use clap::builder::styling::{AnsiColor, Effects, Styles};
 use crossterm::{

--- a/src/ui/alloc_tests.rs
+++ b/src/ui/alloc_tests.rs
@@ -7,8 +7,10 @@
 //!
 //! The measurement uses the test-only `CountingAllocator` (see
 //! `src/alloc_counter.rs`) which counts allocations on the current thread.
+//!
+//! This module is already gated behind `#[cfg(test)]` at its declaration in
+//! `src/ui/mod.rs`, so no inner `#[cfg(test)]` is needed.
 
-#[cfg(test)]
 mod tests {
     use crate::alloc_counter::count_allocations;
     use crate::core::app_state::AppState;
@@ -45,6 +47,9 @@ mod tests {
     }
 
     fn build_state(count: usize, hosts: &[&str]) -> AppState {
+        // Containers are assigned round-robin via `hosts[i % hosts.len()]`,
+        // which would divide by zero on an empty slice.
+        assert!(!hosts.is_empty(), "build_state requires at least one host");
         let (tx, _rx) = mpsc::channel(100);
         let mut state = AppState::new(
             HashMap::new(),
@@ -84,6 +89,22 @@ mod tests {
             terminal.draw(|f| render_ui(f, state, &styles)).unwrap();
         })
     }
+
+    // About the allocation bounds asserted below.
+    //
+    // These bounds count Rust-level calls into the global allocator, which is
+    // a function of the code and the `ratatui`/`std` versions, not of the host
+    // OS or system allocator — so they are stable across Linux/macOS for a
+    // given toolchain, but expect to re-baseline them after a `ratatui` or Rust
+    // upgrade changes the widget tree or `Vec`/format internals.
+    //
+    // Last measured (dtop's pinned `ratatui`, Rust on aarch64-darwin):
+    //   single-host  = 1271 (bound 1300)
+    //   multi-host   = 1365 (bound 1400)
+    //   per-container = 41.5 (bound 42)
+    // The headroom is deliberately tight so a real regression trips the test;
+    // if a routine toolchain bump pushes a value just over, re-measure (the
+    // `println!`s report the live numbers) and lift the bound to match.
 
     #[test]
     fn render_container_list_steady_state_allocations() {

--- a/src/ui/alloc_tests.rs
+++ b/src/ui/alloc_tests.rs
@@ -1,0 +1,145 @@
+//! Allocation-regression tests for the rendering hot path.
+//!
+//! `dtop` re-renders the whole UI on a timer (every 500ms) and on every event.
+//! The container-list render is the hottest path, so we measure how many heap
+//! allocations a single steady-state frame performs and assert an upper bound.
+//! This both documents the current cost and prevents regressions.
+//!
+//! The measurement uses the test-only `CountingAllocator` (see
+//! `src/alloc_counter.rs`) which counts allocations on the current thread.
+
+#[cfg(test)]
+mod tests {
+    use crate::alloc_counter::count_allocations;
+    use crate::core::app_state::AppState;
+    use crate::core::types::{
+        Column, ColumnConfig, Container, ContainerKey, ContainerState, ContainerStats,
+    };
+    use crate::ui::render::{UiStyles, render_ui};
+    use chrono::Utc;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use std::collections::HashMap;
+    use tokio::sync::mpsc;
+
+    fn make_container(i: usize, host: &str) -> Container {
+        Container {
+            id: format!("container{i:08}"),
+            name: format!("service-{i}"),
+            state: ContainerState::Running,
+            health: None,
+            created: Some(Utc::now() - chrono::Duration::hours(i as i64 + 1)),
+            stats: ContainerStats {
+                cpu: (i as f64 * 3.7) % 100.0,
+                memory: (i as f64 * 5.1) % 100.0,
+                memory_used_bytes: (i as u64 + 1) * 12_345_678,
+                memory_limit_bytes: 2_000_000_000,
+                network_tx_bytes_per_sec: (i as f64) * 1024.0,
+                network_rx_bytes_per_sec: (i as f64) * 2048.0,
+            },
+            host_id: host.to_string(),
+            dozzle_url: None,
+            restart_count: Some(i as i64 % 4),
+            compose_project: Some(format!("project-{}", i % 3)),
+        }
+    }
+
+    fn build_state(count: usize, hosts: &[&str]) -> AppState {
+        let (tx, _rx) = mpsc::channel(100);
+        let mut state = AppState::new(
+            HashMap::new(),
+            tx,
+            false,
+            Column::Uptime,
+            ColumnConfig::default(),
+            None,
+        );
+
+        for i in 0..count {
+            let host = hosts[i % hosts.len()];
+            let container = make_container(i, host);
+            let key = ContainerKey::new(container.host_id.clone(), container.id.clone());
+            state.containers.insert(key.clone(), container);
+        }
+        state.force_sort_containers();
+        state.table_state.select(Some(0));
+        state
+    }
+
+    /// Renders one steady-state frame and returns the allocation count.
+    ///
+    /// The first render is a warm-up: it lets `Terminal` allocate its double
+    /// buffers and lets any lazily-initialized caches populate. We then measure
+    /// a second identical render, which represents the steady-state cost.
+    fn measure_render(state: &mut AppState, w: u16, h: u16) -> u64 {
+        let styles = UiStyles::default();
+        let backend = TestBackend::new(w, h);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        // Warm-up render.
+        terminal.draw(|f| render_ui(f, state, &styles)).unwrap();
+
+        // Measured render (identical content, same terminal/buffers).
+        count_allocations(|| {
+            terminal.draw(|f| render_ui(f, state, &styles)).unwrap();
+        })
+    }
+
+    #[test]
+    fn render_container_list_steady_state_allocations() {
+        let mut state = build_state(30, &["local"]);
+        let allocs = measure_render(&mut state, 140, 40);
+        println!("single-host steady-state render (30 containers) allocations: {allocs}");
+
+        // Upper bound guarding against regressions. The bulk of this number is
+        // structural: ratatui's immediate-mode `Table`/`Row`/`Cell`/`Text`
+        // widgets allocate ~2 Vecs per cell every frame (see
+        // `render_marginal_allocations_per_container`). Per-frame constant
+        // overhead (host-column detection, visible-column list) is now
+        // allocation-free.
+        assert!(
+            allocs <= 1300,
+            "steady-state render allocated {allocs} times (expected <= 1300)"
+        );
+    }
+
+    #[test]
+    fn render_multi_host_steady_state_allocations() {
+        let mut state = build_state(30, &["local", "user@server1", "root@10.0.0.5"]);
+        let allocs = measure_render(&mut state, 160, 40);
+        println!("multi-host steady-state render (30 containers) allocations: {allocs}");
+
+        assert!(
+            allocs <= 1400,
+            "multi-host steady-state render allocated {allocs} times (expected <= 1400)"
+        );
+    }
+
+    /// Measures the marginal allocation cost of each additional rendered
+    /// container by comparing renders at two container counts in a viewport
+    /// tall enough to show them all.
+    ///
+    /// This isolates the per-row cost from the per-frame constant overhead and
+    /// guards it against regression. The remaining per-row cost is dominated by
+    /// ratatui's widget tree (one `Cell`/`Text`/`Line` per column per row);
+    /// the per-frame constant overhead has been driven to zero.
+    #[test]
+    fn render_marginal_allocations_per_container() {
+        let mut small = build_state(10, &["local"]);
+        let mut large = build_state(80, &["local"]);
+
+        let small_allocs = measure_render(&mut small, 140, 100);
+        let large_allocs = measure_render(&mut large, 140, 100);
+
+        let per_container = (large_allocs - small_allocs) as f64 / 70.0;
+        println!(
+            "render allocations: 10 containers={small_allocs}, 80 containers={large_allocs} \
+             ({per_container:.1} allocs/container)"
+        );
+
+        assert!(
+            per_container <= 42.0,
+            "per-container render allocation cost regressed to {per_container:.1} (expected <= 42)"
+        );
+    }
+}

--- a/src/ui/container_list.rs
+++ b/src/ui/container_list.rs
@@ -1,6 +1,6 @@
 use crate::core::app_state::AppState;
 use crate::core::types::{Column, Container, ContainerState, HealthStatus, SortState};
-use crate::ui::formatters::{format_bytes, format_bytes_per_sec, format_time_elapsed};
+use crate::ui::formatters::{format_bytes_per_sec, format_time_elapsed, write_bytes};
 use crate::ui::render::UiStyles;
 use ratatui::{
     Frame,
@@ -24,7 +24,10 @@ pub fn render_container_list(
 
     app_state.sort_containers();
 
-    let visible_columns = app_state.column_config.visible_columns();
+    // Refresh the reusable visible-columns buffer in place (no per-frame alloc),
+    // then borrow it for the rest of the render.
+    app_state.refresh_visible_columns();
+    let visible_columns = &app_state.visible_columns_cache;
 
     let rows: Vec<Row> = app_state
         .sorted_container_keys
@@ -34,7 +37,7 @@ pub fn render_container_list(
             create_container_row(
                 c,
                 styles,
-                &visible_columns,
+                visible_columns,
                 show_host_column,
                 show_progress_bars,
             )
@@ -43,7 +46,7 @@ pub fn render_container_list(
 
     let header = create_header_row(
         styles,
-        &visible_columns,
+        visible_columns,
         show_host_column,
         app_state.sort_state,
     );
@@ -52,7 +55,7 @@ pub fn render_container_list(
         header,
         app_state.sorted_container_keys.len(),
         styles,
-        &visible_columns,
+        visible_columns,
         show_host_column,
         show_progress_bars,
     );
@@ -176,7 +179,6 @@ fn create_progress_bar(percentage: f64, width: usize) -> String {
 
 /// Creates a text-based progress bar with memory used/limit display
 fn create_memory_progress_bar(percentage: f64, used: u64, limit: u64, width: usize) -> String {
-    use std::fmt::Write;
     // Clamp the bar visual to 100%, but display the actual percentage value
     let bar_percentage = percentage.clamp(0.0, 100.0);
     let filled_width = ((bar_percentage / 100.0) * width as f64).round() as usize;
@@ -184,7 +186,12 @@ fn create_memory_progress_bar(percentage: f64, used: u64, limit: u64, width: usi
 
     let mut result = String::with_capacity(width * 3 + 20);
     write_bar(&mut result, filled_width, empty_width);
-    let _ = write!(result, " {}/{}", format_bytes(used), format_bytes(limit));
+    // Format the byte values directly into `result` to avoid two intermediate
+    // String allocations per row.
+    result.push(' ');
+    write_bytes(&mut result, used);
+    result.push('/');
+    write_bytes(&mut result, limit);
     result
 }
 

--- a/src/ui/formatters.rs
+++ b/src/ui/formatters.rs
@@ -26,23 +26,23 @@ fn write_byte_value(
     let (gb_prec, mb_prec, kb_prec, b_prec) = precisions;
     let b = if include_b { "B" } else { "" };
 
-    // `write!` to a `String` is infallible; the `let _` discards the Result.
-    let _ = if value >= GB {
+    // `write!` to a `String` is infallible, so each `let _` discards the Result.
+    if value >= GB {
         let gb = value / GB;
         // When precision is 0, show one decimal for fractional values so
         // 1.5G doesn't render as 2G. Whole numbers stay clean (e.g. "4G").
         if gb_prec == 0 && (gb - gb.round()).abs() >= 0.05 {
-            write!(buf, "{:.1}G{}{}", gb, b, suffix)
+            let _ = write!(buf, "{:.1}G{}{}", gb, b, suffix);
         } else {
-            write!(buf, "{:.prec$}G{}{}", gb, b, suffix, prec = gb_prec)
+            let _ = write!(buf, "{:.prec$}G{}{}", gb, b, suffix, prec = gb_prec);
         }
     } else if value >= MB {
-        write!(buf, "{:.prec$}M{}{}", value / MB, b, suffix, prec = mb_prec)
+        let _ = write!(buf, "{:.prec$}M{}{}", value / MB, b, suffix, prec = mb_prec);
     } else if value >= KB {
-        write!(buf, "{:.prec$}K{}{}", value / KB, b, suffix, prec = kb_prec)
+        let _ = write!(buf, "{:.prec$}K{}{}", value / KB, b, suffix, prec = kb_prec);
     } else {
-        write!(buf, "{:.prec$}B{}", value, suffix, prec = b_prec)
-    };
+        let _ = write!(buf, "{:.prec$}B{}", value, suffix, prec = b_prec);
+    }
 }
 
 /// Writes a human-readable byte value (B, K, M, G) into an existing buffer.

--- a/src/ui/formatters.rs
+++ b/src/ui/formatters.rs
@@ -1,6 +1,7 @@
 //! Formatting utilities for displaying values in the UI
 
 use chrono::Utc;
+use std::fmt::Write;
 use std::sync::LazyLock;
 use timeago::Formatter;
 
@@ -10,42 +11,61 @@ const KB: f64 = 1024.0;
 const MB: f64 = KB * 1024.0;
 const GB: f64 = MB * 1024.0;
 
-/// Formats a byte value with the appropriate unit
-fn format_byte_value(
+/// Writes a byte value with the appropriate unit into an existing buffer.
+///
+/// This is the allocation-free core used by both the `String`-returning
+/// helpers and the hot-path renderers that format directly into a reused
+/// buffer.
+fn write_byte_value(
+    buf: &mut String,
     value: f64,
     suffix: &str,
     include_b: bool,
     precisions: (usize, usize, usize, usize),
-) -> String {
+) {
     let (gb_prec, mb_prec, kb_prec, b_prec) = precisions;
     let b = if include_b { "B" } else { "" };
 
-    if value >= GB {
+    // `write!` to a `String` is infallible; the `let _` discards the Result.
+    let _ = if value >= GB {
         let gb = value / GB;
         // When precision is 0, show one decimal for fractional values so
         // 1.5G doesn't render as 2G. Whole numbers stay clean (e.g. "4G").
         if gb_prec == 0 && (gb - gb.round()).abs() >= 0.05 {
-            format!("{:.1}G{}{}", gb, b, suffix)
+            write!(buf, "{:.1}G{}{}", gb, b, suffix)
         } else {
-            format!("{:.prec$}G{}{}", gb, b, suffix, prec = gb_prec)
+            write!(buf, "{:.prec$}G{}{}", gb, b, suffix, prec = gb_prec)
         }
     } else if value >= MB {
-        format!("{:.prec$}M{}{}", value / MB, b, suffix, prec = mb_prec)
+        write!(buf, "{:.prec$}M{}{}", value / MB, b, suffix, prec = mb_prec)
     } else if value >= KB {
-        format!("{:.prec$}K{}{}", value / KB, b, suffix, prec = kb_prec)
+        write!(buf, "{:.prec$}K{}{}", value / KB, b, suffix, prec = kb_prec)
     } else {
-        format!("{:.prec$}B{}", value, suffix, prec = b_prec)
-    }
+        write!(buf, "{:.prec$}B{}", value, suffix, prec = b_prec)
+    };
 }
 
-/// Formats bytes into a human-readable string (B, K, M, G)
+/// Writes a human-readable byte value (B, K, M, G) into an existing buffer.
+pub fn write_bytes(buf: &mut String, bytes: u64) {
+    write_byte_value(buf, bytes as f64, "", false, (0, 0, 0, 0));
+}
+
+/// Formats bytes into a human-readable string (B, K, M, G).
+///
+/// Production rendering uses `write_bytes` to format directly into a reused
+/// buffer; this `String`-returning convenience wrapper is retained for tests.
+#[cfg(test)]
 pub fn format_bytes(bytes: u64) -> String {
-    format_byte_value(bytes as f64, "", false, (0, 0, 0, 0))
+    let mut s = String::new();
+    write_bytes(&mut s, bytes);
+    s
 }
 
 /// Formats bytes per second into a human-readable string (KB/s, MB/s, GB/s)
 pub fn format_bytes_per_sec(bytes_per_sec: f64) -> String {
-    format_byte_value(bytes_per_sec, "/s", true, (2, 2, 1, 0))
+    let mut s = String::new();
+    write_byte_value(&mut s, bytes_per_sec, "/s", true, (2, 2, 1, 0));
+    s
 }
 
 /// Formats the time elapsed since container creation

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,4 +10,6 @@ pub mod render;
 pub mod sort_selector;
 
 #[cfg(test)]
+mod alloc_tests;
+#[cfg(test)]
 mod ui_tests;

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -74,11 +74,7 @@ pub fn render_ui(f: &mut Frame, state: &mut AppState, styles: &UiStyles) {
     // Render main content
     match &state.view_state {
         ViewState::ContainerList | ViewState::SearchMode => {
-            // Calculate unique hosts to determine if host column should be shown
-            let unique_hosts: std::collections::HashSet<_> =
-                state.containers.keys().map(|key| &key.host_id).collect();
-            let show_host_column = unique_hosts.len() > 1;
-
+            let show_host_column = state.has_multiple_hosts();
             render_container_list(f, size, state, styles, show_host_column);
         }
         ViewState::LogView(container_key) => {
@@ -86,9 +82,7 @@ pub fn render_ui(f: &mut Frame, state: &mut AppState, styles: &UiStyles) {
             render_log_view(f, size, &container_key, state, styles);
         }
         ViewState::ColumnSelector | ViewState::SortSelector => {
-            let unique_hosts: std::collections::HashSet<_> =
-                state.containers.keys().map(|key| &key.host_id).collect();
-            let show_host_column = unique_hosts.len() > 1;
+            let show_host_column = state.has_multiple_hosts();
             render_container_list(f, size, state, styles, show_host_column);
             if state.view_state == ViewState::ColumnSelector {
                 render_column_selector(f, state, styles);
@@ -98,10 +92,7 @@ pub fn render_ui(f: &mut Frame, state: &mut AppState, styles: &UiStyles) {
         }
         ViewState::ActionMenu(_) => {
             // First render the container list in the background
-            let unique_hosts: std::collections::HashSet<_> =
-                state.containers.keys().map(|key| &key.host_id).collect();
-            let show_host_column = unique_hosts.len() > 1;
-
+            let show_host_column = state.has_multiple_hosts();
             render_container_list(f, size, state, styles, show_host_column);
 
             // Then render the action menu on top


### PR DESCRIPTION
## Summary

This PR adds comprehensive allocation-regression tests to measure and prevent heap allocation regressions in the rendering hot path, and optimizes the container list renderer to eliminate per-frame allocations where possible.

## Key Changes

**Allocation Regression Testing Infrastructure:**
- Added `src/alloc_counter.rs`: A test-only `CountingAllocator` that wraps the system allocator and counts heap allocations on the current thread using thread-local state
- Added `src/ui/alloc_tests.rs`: Three allocation-regression tests that measure steady-state rendering costs:
  - Single-host render with 30 containers (≤1300 allocations)
  - Multi-host render with 30 containers (≤1400 allocations)
  - Per-container marginal allocation cost (≤42 allocations/container)
- Registered the `CountingAllocator` as the global allocator in both `src/lib.rs` and `src/main.rs` for test execution

**Hot-Path Rendering Optimizations:**
- **Visible columns caching**: Added `visible_columns_cache` to `AppState` that is refreshed in-place each frame (clear + extend), eliminating per-frame `Vec` allocation for the visible columns list
- **Allocation-free host detection**: Implemented `AppState::has_multiple_hosts()` that iterates container keys with early return instead of collecting into a `HashSet`, performing zero heap allocations
- **Direct buffer formatting**: Refactored `src/ui/formatters.rs` to provide `write_bytes()` that formats directly into an existing `String` buffer, avoiding intermediate allocations
- **Memory progress bar optimization**: Updated `create_memory_progress_bar()` to format byte values directly into the result buffer instead of creating intermediate `String` objects

**Code Organization:**
- Moved `format_bytes()` to test-only (marked `#[cfg(test)]`) since production rendering now uses `write_bytes()`
- Updated `src/ui/render.rs` to use the new `has_multiple_hosts()` method instead of creating temporary `HashSet`s
- Updated `src/ui/container_list.rs` to use the cached visible columns and direct buffer formatting

## Implementation Details

The allocation counter uses thread-local state (`ENABLED` and `COUNT`) to track allocations only when explicitly enabled, allowing parallel test execution without interference. The `record_alloc()` function is called from `alloc()`, `alloc_zeroed()`, and `realloc()` to capture all allocation events relevant to the hot path.

The visible columns cache reuses the same `Vec` across frames by clearing and extending it, which is more efficient than creating a new `Vec` each time. The `has_multiple_hosts()` method avoids allocations by using an early-return pattern instead of collecting unique hosts into a set.

These optimizations reduce the per-frame allocation count from structural overhead while maintaining code clarity and correctness.

https://claude.ai/code/session_01KdiZdKYcPugWwy2Bm8qdRo